### PR TITLE
docs: formatting improvements

### DIFF
--- a/docs/genesis.md
+++ b/docs/genesis.md
@@ -1,8 +1,8 @@
 # Joining the Genesis
 
-** These steps have been automated for the Athens3 testnet via the
+**These steps have been automated for the Athens3 testnet via the
 `node-setup.sh` and `start-zetaclient.sh` scripts. Operators should ignore this
-document unless you they to perform their key generation manually**
+document unless you they to perform their key generation manually.**
 
 The genesis file is a JSON file which defines the initial state of a blockchain.
 It can be seen as height **0** of the blockchain. The first block, at
@@ -13,7 +13,7 @@ This document describes how to join this initial state.
 
 ### Requirements
 
-Your node must be setup as a validator and it will be part of the active set at
+Your node must be setup as a validator, and it will be part of the active set at
 its initial state.
 
 ### Deploy a Node
@@ -32,67 +32,73 @@ Create the account `val` on your node.
 Make sure to securely store the mnemonic from the output in a safe place. You
 will need this information to later access your account.
 
-`bash zetacored keys add val --algo secp256k1 `
+```
+zetacored keys add val --algo secp256k1
+```
 
 ### Submit Your Validator Account Address
 
 Display your validator account address to be submitted on the Zetachain Support
-Channel
+Channel:
 
-`jsx zetacored keys show val -a `
+```
+zetacored keys show val -a
+```
 
-### Install the Genesis File Pre-gentx
+### Install the Initial Genesis File
 
-You will receive a pre-gentx genesis file on the Zetachain Support Channel.
-Install it as follow
+You will receive an initial genesis file on the Zetachain Support Channel.
+Install it in the following location:
 
-`jsx ~/.zetacored/config/genesis.json `
+```
+~/.zetacored/config/genesis.json
+```
 
 ### Generate a Genesis Transaction
 
 This genesis file does not contain any `gentxs`. A `gentx` is a transaction that
-bonds staking token present in the genesis file under `accounts`to a validator,
+bonds staking token present in the genesis file under `accounts` to a validator,
 essentially creating a validator at genesis.
 
 The following command will generate a genesis transaction that creates a
 validator with a self-delegation.
 
-```bash zetacored gentx val <delegation_amount> \
-  --chain-id $(zetacored config chain-id) \ --ip <public_ip> \ --moniker
-  <moniker> \ --commission-rate <commission_rate> \ --commission-max-rate
-  <commission_max_rate> \ --commission-max-change-rate
-  <commission_max_change_rate>
+```bash
+zetacored gentx val <delegation_amount> \
+  --chain-id $(zetacored config chain-id) \
+  --ip <public_ip> \
+  --moniker <moniker> \
+  --commission-rate <commission_rate> \
+  --commission-max-rate <commission_max_rate> \
+  --commission-max-change-rate <commission_max_change_rate>
 ```
 
-- `delegation_amount` is the amount to be delegate in `azeta` - `public_ip` is
-  your public IP. If you’re using sentry architecture, this would be one of your
-  sentry public IP - `moniker` is the moniker for your node (ex. “my_node”) -
-  `commission_rate` is the initial commission rate percentage (optional, default
-  value is 0.1) - `commission_max_rate` is the maximum commission rate
-  percentage (optional, default value 0.2) - `commission_max_change_rate` is the
-  maximum commission change rate percentage per day (optional, default value
-  0.01)
+- `delegation_amount` is the amount to be delegate in `azeta`
+- `public_ip` is your public IP. If you’re using sentry architecture, this would
+  be one of your sentry public IP - `moniker` is the moniker for your node (ex.
+  “my_node”)
+- `commission_rate` is the initial commission rate percentage (optional, default
+  value is 0.1)
+- `commission_max_rate` is the maximum commission rate percentage (optional,
+  default value 0.2)
+- `commission_max_change_rate` is the maximum commission change rate percentage
+  per day (optional, default value 0.01)
 
 > `commission-max-rate` and `commission-max-change-rate` cannot be changed once
-> a validator is up and running. >
+> a validator is up and running.
 
 ### Submit Your Genesis Transaction File
 
 You can find your genesis transaction JSON file in the following directory.
-Submit it on the ZetaChain Support Channel
+Submit it on the ZetaChain Support Channel.
 
-`jsx ~/.zetacored/config/gentx `
+```
+~/.zetacored/config/gentx
+```
 
 ### Install the Genesis File
 
 Once the final ZetaChain genesis file is ready, there will be an announcement
 that it can be downloaded from our URL:
 
-```jsx
 https://zetachain-external-files.s3.amazonaws.com/genesis/athens3/genesis.json
-```
-
-### Complete Node Deployment
-
-Continue your node deployment by following the instruction**s** below **starting
-after the install genesis file** step

--- a/docs/genesis.md
+++ b/docs/genesis.md
@@ -4,7 +4,6 @@
 `node-setup.sh` and `start-zetaclient.sh` scripts. Operators should ignore this
 document unless you they to perform their key generation manually**
 
-
 The genesis file is a JSON file which defines the initial state of a blockchain.
 It can be seen as height **0** of the blockchain. The first block, at
 height **1**, will reference the genesis file as its parent. It is needed to
@@ -15,40 +14,39 @@ This document describes how to join this initial state.
 ### Requirements
 
 Your node must be setup as a validator and it will be part of the active set at
-its initial state. 
+its initial state.
 
 ### Deploy a Node
 
 If you have not already deployed a node, follow the instruction below but stop
 at **Install Genesis File.**
 
-[Hosting a
-Node](https://www.notion.so/Hosting-a-Node-64709ea14b6549b8abd45cd3299e8bff)
+[Hosting a Node](https://www.notion.so/Hosting-a-Node-64709ea14b6549b8abd45cd3299e8bff)
 
 In the following process, you will participate in generating the genesis file.
 
 ### Create a Validator Account
 
-Create the account `val` on your node. 
+Create the account `val` on your node.
 
 Make sure to securely store the mnemonic from the output in a safe place. You
 will need this information to later access your account.
 
-```bash zetacored keys add val --algo secp256k1 ```
+`bash zetacored keys add val --algo secp256k1 `
 
 ### Submit Your Validator Account Address
 
 Display your validator account address to be submitted on the Zetachain Support
-Channel 
+Channel
 
-```jsx zetacored keys show val -a ```
+`jsx zetacored keys show val -a `
 
 ### Install the Genesis File Pre-gentx
 
 You will receive a pre-gentx genesis file on the Zetachain Support Channel.
 Install it as follow
 
-```jsx ~/.zetacored/config/genesis.json ```
+`jsx ~/.zetacored/config/genesis.json `
 
 ### Generate a Genesis Transaction
 
@@ -57,7 +55,7 @@ bonds staking token present in the genesis file under `accounts`to a validator,
 essentially creating a validator at genesis.
 
 The following command will generate a genesis transaction that creates a
-validator with a self-delegation. 
+validator with a self-delegation.
 
 ```bash zetacored gentx val <delegation_amount> \
   --chain-id $(zetacored config chain-id) \ --ip <public_ip> \ --moniker
@@ -67,22 +65,23 @@ validator with a self-delegation.
 ```
 
 - `delegation_amount` is the amount to be delegate in `azeta` - `public_ip` is
-your public IP. If you’re using sentry architecture, this would be one of your
-sentry public IP - `moniker` is the moniker for your node (ex. “my_node”) -
-`commission_rate` is the initial commission rate percentage (optional, default
-value is 0.1) - `commission_max_rate` is the maximum commission rate percentage
-(optional, default value 0.2) - `commission_max_change_rate` is the maximum
-commission change rate percentage per day (optional, default value 0.01)
+  your public IP. If you’re using sentry architecture, this would be one of your
+  sentry public IP - `moniker` is the moniker for your node (ex. “my_node”) -
+  `commission_rate` is the initial commission rate percentage (optional, default
+  value is 0.1) - `commission_max_rate` is the maximum commission rate
+  percentage (optional, default value 0.2) - `commission_max_change_rate` is the
+  maximum commission change rate percentage per day (optional, default value
+  0.01)
 
 > `commission-max-rate` and `commission-max-change-rate` cannot be changed once
-a validator is up and running. > 
+> a validator is up and running. >
 
 ### Submit Your Genesis Transaction File
 
 You can find your genesis transaction JSON file in the following directory.
 Submit it on the ZetaChain Support Channel
 
-```jsx ~/.zetacored/config/gentx ```
+`jsx ~/.zetacored/config/gentx `
 
 ### Install the Genesis File
 

--- a/docs/keygen.md
+++ b/docs/keygen.md
@@ -1,8 +1,8 @@
 ## Keygen Ceremony
 
-** These steps have been automated for the Athens3 testnet via the
+**These steps have been automated for the Athens3 testnet via the
 `node-setup.sh` and `start-zetaclient.sh` scripts. Operators should ignore this
-document unless you they to perform their key generation manually**
+document unless you they to perform their key generation manually.**
 
 During the genesis process of the Athens3 testnet, the TSS Signers (validators
 who are in the set of TSSSigner) need to coordinate the generation of a TSS
@@ -15,7 +15,7 @@ keygen ceremony will begin at block `<block num>`.
 First, query the seed node to join the zetaclient p2p network:
 
 ```bash
-export SEEDIP=3.141.21.139 
+export SEEDIP=3.141.21.139
 export SEED=$(curl --retry 10 --retry-delay 5 --retry-connrefused  -s $SEEDIP:8123/p2p)
 ```
 
@@ -27,8 +27,8 @@ echo $SEED 16Uiu2HAkzocxERFCih7PZWCzyoncZ9MEbH8M4Bi3dPjrzBb8tSEY
 ```
 
 If your node has a public IP and private IP (such as AWS EC2 instance), then you
-need to set the `MYIP` environment variable to your public IP otherwise
-the p2p connection will not work.
+need to set the `MYIP` environment variable to your public IP otherwise the p2p
+connection will not work.
 
 ```bash
 export MYIP=3.141.21.139

--- a/docs/start_here.md
+++ b/docs/start_here.md
@@ -82,8 +82,7 @@ NOTE : A backup up is created for the existing zetacored folder under
 
 ### Get Updated Genesis File
 
-After the ZetaChain Coordinator has merged the PRs and updated the genesis
-file:
+After the ZetaChain Coordinator has merged the PRs and updated the genesis file:
 
 - Switch back to the `main` branch
 - Pull the latest changes to get the updated genesis.json file
@@ -99,10 +98,10 @@ git pull
 ./scripts/start-zetacore.sh
 ```
 
-**Optional** The start-zetacore.sh script will automatically update the config file
-(~/.zetacored/config/config.toml) with a persistent peer. If you did not use
-the start-zetacored.sh script you need to update the config file manually with
-the peer information.
+**Optional** The start-zetacore.sh script will automatically update the config
+file (~/.zetacored/config/config.toml) with a persistent peer. If you did not
+use the start-zetacored.sh script you need to update the config file manually
+with the peer information.
 
 #### Wait for Genesis to Complete
 
@@ -115,20 +114,21 @@ management system. See the final section below for more information.
 pkill zetacored
 ```
 
-If you are an Observer Signer Validator you must leave zetacored running and move onto the next step.
+If you are an Observer Signer Validator you must leave zetacored running and
+move onto the next step.
 
 ## Phase 3: TSS Keygen (zetaclientd)
 
-This phase applies to **Observer/Signer Validators only**. Most operators are `core
-validators` and can skip this step. If you aren't sure what you are, you are
-most likely a core validator.
+This phase applies to **Observer/Signer Validators only**. Most operators are
+`core validators` and can skip this step. If you aren't sure what you are, you
+are most likely a core validator.
 
 #### Configure RPC Connectivity
 
-Observer Signers need an RPC endpoint for each connected chain. You can follow the
-standard instructions to configure a node for most chains but the BTC requires
-special instructions just for ZetaChain. The links below will take you to a node setup guide for
-each chain.
+Observer Signers need an RPC endpoint for each connected chain. You can follow
+the standard instructions to configure a node for most chains but the BTC
+requires special instructions just for ZetaChain. The links below will take you
+to a node setup guide for each chain.
 
 - [Ethereum RPC Node Setup](https://ethereum.org/en/developers/docs/nodes-and-clients/run-a-node/)
 - [BSC RPC Node Setup](https://docs.bnbchain.org/docs/validator/fullnode/)
@@ -139,9 +139,10 @@ Edit the `zeta-client.toml` file located in the `.zetacored/config` directory
 and add the RPC endpoints to the `Endpoint = ` section of each chain.
 
 #### Set Public IP
+
 If your node has a public IP and private IP (such as AWS EC2 instance), then you
-need to set the `MYIP` environment variable to your public IP otherwise
-the p2p connection will not work.
+need to set the `MYIP` environment variable to your public IP otherwise the p2p
+connection will not work.
 
 ```bash
 export MYIP=3.141.21.139
@@ -157,8 +158,8 @@ KEYGENBLOCK=<Keygen Block Provided By ZetaChain Coordinator>
 ./scripts/start-zetaclient.sh -k $KEYGENBLOCK-s $SEEDIP
 ```
 
-**Wait until zetachain coordinator confirms that TSS keygen is completed**.
-Then terminate the processes `zetacored` and `zetaclientd`.
+**Wait until zetachain coordinator confirms that TSS keygen is completed**. Then
+terminate the processes `zetacored` and `zetaclientd`.
 
 ```bash
 pkill zetaclientd
@@ -174,8 +175,10 @@ environment you are running the validator in. At a minimum we reccomend you:
 - [ ] Run each process as a systemd service or containerized service
 - [ ] Do NOT run these services as root. Create a new restricted ZetaChain user
 - [ ] Create Sentry nodes to protect your validator
-- [ ] Setup ngnix to forward p2p traffic from Sentry node to zetaclientd -- TODO add documentation for this
+- [ ] Setup ngnix to forward p2p traffic from Sentry node to zetaclientd -- TODO
+      add documentation for this
 - [ ] Make sure you setup resource monitoring (CPU, RAM, etc), uptime
-      monitoring, log ingestion, etc to minimize the risk of downtime or slashing
-- [ ] Install adequate security measures such as, Endpoint protection, Anti-Virus,
-      system level logging, WAF, etc
+      monitoring, log ingestion, etc to minimize the risk of downtime or
+      slashing
+- [ ] Install adequate security measures such as, Endpoint protection,
+      Anti-Virus, system level logging, WAF, etc

--- a/docs/start_here.md
+++ b/docs/start_here.md
@@ -46,7 +46,7 @@ mv zetaclientd-ubuntu /usr/bin/zetaclientd && chmod +x /usr/bin/zetaclientd
 # You may need to set additional permissions depending on your node configuration
 ```
 
-#### Clone the network github repository
+#### Clone the network GitHub repository
 
 ```bash
 git clone https://github.com/zeta-chain/network-athens3.git && cd network-athens3
@@ -64,7 +64,7 @@ chmod +x ./scripts/*.sh
 ```
 
 After the `node-setup.sh` script generates the keys and necessary files, create
-a branch, commit, and raise a PR to submit the files to zetachain coordinator:
+a branch, commit, and raise a PR to submit the files to ZetaChain coordinator:
 
 - Use `gen-files-<YourValidatorName>` as the branch name for the new branch.
 - The pr must contain only two files
@@ -82,7 +82,7 @@ NOTE : A backup up is created for the existing zetacored folder under
 
 ### Get Updated Genesis File
 
-After the ZetaChain Coordinator has merged the PRs and updated the genesis file:
+After the ZetaChain coordinator has merged the PRs and updated the genesis file:
 
 - Switch back to the `main` branch
 - Pull the latest changes to get the updated genesis.json file
@@ -98,9 +98,9 @@ git pull
 ./scripts/start-zetacore.sh
 ```
 
-**Optional** The start-zetacore.sh script will automatically update the config
-file (~/.zetacored/config/config.toml) with a persistent peer. If you did not
-use the start-zetacored.sh script you need to update the config file manually
+**Optional** The `start-zetacore.sh` script will automatically update the config
+file (`~/.zetacored/config/config.toml`) with a persistent peer. If you did not
+use the `start-zetacored.sh` script you need to update the config file manually
 with the peer information.
 
 #### Wait for Genesis to Complete
@@ -117,13 +117,13 @@ pkill zetacored
 If you are an Observer Signer Validator you must leave zetacored running and
 move onto the next step.
 
-## Phase 3: TSS Keygen (zetaclientd)
+## Phase 3: TSS Keygen (`zetaclientd`)
 
 This phase applies to **Observer/Signer Validators only**. Most operators are
-`core validators` and can skip this step. If you aren't sure what you are, you
+"core validators" and can skip this step. If you aren't sure what you are, you
 are most likely a core validator.
 
-#### Configure RPC Connectivity
+### Configure RPC Connectivity
 
 Observer Signers need an RPC endpoint for each connected chain. You can follow
 the standard instructions to configure a node for most chains but the BTC
@@ -138,7 +138,7 @@ to a node setup guide for each chain.
 Edit the `zeta-client.toml` file located in the `.zetacored/config` directory
 and add the RPC endpoints to the `Endpoint = ` section of each chain.
 
-#### Set Public IP
+### Set Public IP
 
 If your node has a public IP and private IP (such as AWS EC2 instance), then you
 need to set the `MYIP` environment variable to your public IP otherwise the p2p
@@ -148,17 +148,17 @@ connection will not work.
 export MYIP=3.141.21.139
 ```
 
-#### Start Zetaclient
+### Start `zetaclient`
 
-- `KeygenBlock` will be provided by the ZetaChain Coordinator.
+- `KeygenBlock` will be provided by the ZetaChain coordinator.
 
 ```bash
 SEEDIP=3.218.170.198
-KEYGENBLOCK=<Keygen Block Provided By ZetaChain Coordinator>
+KEYGENBLOCK=<Keygen Block Provided By ZetaChain coordinator>
 ./scripts/start-zetaclient.sh -k $KEYGENBLOCK-s $SEEDIP
 ```
 
-**Wait until zetachain coordinator confirms that TSS keygen is completed**. Then
+**Wait until ZetaChain coordinator confirms that TSS keygen is completed**. Then
 terminate the processes `zetacored` and `zetaclientd`.
 
 ```bash


### PR DESCRIPTION
Made some formatting changes to improve readability.

I propose we remove `orchestrator.md`, because most likely the ZetaCore team will be coordinating the launch, so this document is not useful for literally 99% of users.

I also propose moving `genesis.md` and `keygen.md` into a directory called `optional` or `advanced`, because most likely these files will not be needed for validators.