### PR TITLE
fix setup scripts and genesis.config file

### DIFF
--- a/network_files/config/genesis.json
+++ b/network_files/config/genesis.json
@@ -1575,121 +1575,6 @@
     "crosschain": {
       "params": {},
       "outTxTrackerList": [],
-      "keygen": {
-        "granteePubkeys": [
-          "zetapub1addwnpepqdljmtptxflv3cs3q79v8pvaynu7ep9eglwvyxv7v3a5mpccvmcg7hpywrc",
-          "zetapub1addwnpepqf8ngvcs27m4hm8m2e8fupulu3qsvutf7lflds2c0deqmamkdrymvp5u0g6",
-          "zetapub1addwnpepq2ayeqvgmdau45rqxapal8j5jd6we55y3j7jlphqner8mvtj3jl454mpuhn",
-          "zetapub1addwnpepqf7dw2fnf6ntl6f8d3yw7jly8a535cgum9tuur55k2c064pq0ysl5u2fw5m",
-          "zetapub1addwnpepq09ywklml6wts0eua3zhmtcw38rf4kel0zg2d4dhd46zv00mkjz45gn9phl",
-          "zetapub1addwnpepqdj8ww4u40wkg2whl22qvmm2zdsdn5rt4yegr6zc6sw9zqdvr8mx54nhke5",
-          "zetapub1addwnpepqwsl5cqjj57aw5rn79j44pyp0322nu6cxx28hfrqn5gwfcaau27tgm3p0z2",
-          "zetapub1addwnpepqtft2rac0xtu25v3knnhktyjyp0wehfwj0lg8z24g5asfu0lf0dh7xqyfpf",
-          "zetapub1addwnpepq02ppdhgdnffaz9mkswx8xu04wlcqjtqc6tgnmsj62fa9ef202v77c9ugp6",
-          "zetapub1addwnpepq2vduhrgfmvjjjvmh7h90ewm9d98gtj2xkvvduqcgr7lk0ejxgltsngchvu",
-          "zetapub1addwnpepq08m4vw832r4hwt6nwa0fa6ze8c4ue6k9yqjul9ap25hcndv44fsquw5eg2",
-          "zetapub1addwnpepqdy8mm6jemgeyv9g7f7ymk5cymal4zms6t2n0ml0tk9ajak0c8n77790s52"
-        ],
-        "blockNumber": 14400
-      },
-      "nodeAccountList": [
-        {
-          "operator": "zeta1ggqzjf5726uu7xc6pfwg00lny79w6t3a3utpw5",
-          "granteeAddress": "zeta152ka0ynl4p62wwsesd7rmxpcsdh0z437vf3vyr",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepqdljmtptxflv3cs3q79v8pvaynu7ep9eglwvyxv7v3a5mpccvmcg7hpywrc"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta1hk05v9len8u0c2xrwxgfknvcskpd4vncm7ehch",
-          "granteeAddress": "zeta1e07th0309p0mh9s03l79yz08ka8ptu6xsza0cc",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepqf8ngvcs27m4hm8m2e8fupulu3qsvutf7lflds2c0deqmamkdrymvp5u0g6"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta1g323lusfa9qqvjvupajre2dphuem999fahc086",
-          "granteeAddress": "zeta15d004cg8knm8nfklwfpkvfhzcvnl6v0xdkmcmy",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepq2ayeqvgmdau45rqxapal8j5jd6we55y3j7jlphqner8mvtj3jl454mpuhn"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta1mte0r3jzkf2rkd7ex4p3xsd3fxqg7q29q0wxl5",
-          "granteeAddress": "zeta1j8yhw9u7a6kdahg8wpyxy5tzxjjh0f0kwd292z",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepqf7dw2fnf6ntl6f8d3yw7jly8a535cgum9tuur55k2c064pq0ysl5u2fw5m"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta18pksjzclks34qkqyaahf2rakss80mnusju77cm",
-          "granteeAddress": "zeta1euvlmpffq7gl77vlwlv97kn004zq6rdw0skdd3",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepq09ywklml6wts0eua3zhmtcw38rf4kel0zg2d4dhd46zv00mkjz45gn9phl"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta18f7wch6kpfdmk6dk9qqhkszpjwrymev4fpte8p",
-          "granteeAddress": "zeta1l2dwhqy94687yja0upaq0v5aukgdepfw0y253j",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepqdj8ww4u40wkg2whl22qvmm2zdsdn5rt4yegr6zc6sw9zqdvr8mx54nhke5"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta1w8qa37h22h884vxedmprvwtd3z2nwakxu9k935",
-          "granteeAddress": "zeta1mr6rqva6d6gnelu7vwl38h0xn7tl67wac7d43e",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepqwsl5cqjj57aw5rn79j44pyp0322nu6cxx28hfrqn5gwfcaau27tgm3p0z2"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta1j8g8ch4uqgl3gtet3nntvczaeppmlxajqwh5u6",
-          "granteeAddress": "zeta122cx6fts6cn70lpwg3t40lyh9gm83269tdfn79",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepqtft2rac0xtu25v3knnhktyjyp0wehfwj0lg8z24g5asfu0lf0dh7xqyfpf"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta1dxyzsket66vt886ap0gnzlnu5pv0y99v086wnz",
-          "granteeAddress": "zeta1stkv3amjhaheg4zp57w3es3yx0qf59zdl4vld2",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepq02ppdhgdnffaz9mkswx8xu04wlcqjtqc6tgnmsj62fa9ef202v77c9ugp6"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta1w5czgpk5kc9etxw2anzhr0uyrr4fqks32qmk6k",
-          "granteeAddress": "zeta19qjs5kpgrmk0mee06k47s7sss95g6s8g34q7gy",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepq2vduhrgfmvjjjvmh7h90ewm9d98gtj2xkvvduqcgr7lk0ejxgltsngchvu"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta1ymnrwg9e3xr9xkw42ygzjx34dyvwvtc23cnnxz",
-          "granteeAddress": "zeta10ju8dap0u9wf50akjgapwagcu2kejuu2qfmk0z",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepq08m4vw832r4hwt6nwa0fa6ze8c4ue6k9yqjul9ap25hcndv44fsquw5eg2"
-          },
-          "nodeStatus": 4
-        },
-        {
-          "operator": "zeta15ruj2tc76pnj9xtw64utktee7cc7w6vzaes73z",
-          "granteeAddress": "zeta1kd4r2ahxz0vpzulrqrvr7a9t7ukcchrggvefhn",
-          "granteePubkey": {
-            "secp256k1": "zetapub1addwnpepqdy8mm6jemgeyv9g7f7ymk5cymal4zms6t2n0ml0tk9ajak0c8n77790s52"
-          },
-          "nodeStatus": 4
-        }
-      ],
       "inTxHashToCctxList": []
     },
     "distribution": {
@@ -3281,6 +3166,121 @@
             "zeta1ymnrwg9e3xr9xkw42ygzjx34dyvwvtc23cnnxz",
             "zeta15ruj2tc76pnj9xtw64utktee7cc7w6vzaes73z"
           ]
+        }
+      ],
+      "keygen": {
+        "granteePubkeys": [
+          "zetapub1addwnpepqdljmtptxflv3cs3q79v8pvaynu7ep9eglwvyxv7v3a5mpccvmcg7hpywrc",
+          "zetapub1addwnpepqf8ngvcs27m4hm8m2e8fupulu3qsvutf7lflds2c0deqmamkdrymvp5u0g6",
+          "zetapub1addwnpepq2ayeqvgmdau45rqxapal8j5jd6we55y3j7jlphqner8mvtj3jl454mpuhn",
+          "zetapub1addwnpepqf7dw2fnf6ntl6f8d3yw7jly8a535cgum9tuur55k2c064pq0ysl5u2fw5m",
+          "zetapub1addwnpepq09ywklml6wts0eua3zhmtcw38rf4kel0zg2d4dhd46zv00mkjz45gn9phl",
+          "zetapub1addwnpepqdj8ww4u40wkg2whl22qvmm2zdsdn5rt4yegr6zc6sw9zqdvr8mx54nhke5",
+          "zetapub1addwnpepqwsl5cqjj57aw5rn79j44pyp0322nu6cxx28hfrqn5gwfcaau27tgm3p0z2",
+          "zetapub1addwnpepqtft2rac0xtu25v3knnhktyjyp0wehfwj0lg8z24g5asfu0lf0dh7xqyfpf",
+          "zetapub1addwnpepq02ppdhgdnffaz9mkswx8xu04wlcqjtqc6tgnmsj62fa9ef202v77c9ugp6",
+          "zetapub1addwnpepq2vduhrgfmvjjjvmh7h90ewm9d98gtj2xkvvduqcgr7lk0ejxgltsngchvu",
+          "zetapub1addwnpepq08m4vw832r4hwt6nwa0fa6ze8c4ue6k9yqjul9ap25hcndv44fsquw5eg2",
+          "zetapub1addwnpepqdy8mm6jemgeyv9g7f7ymk5cymal4zms6t2n0ml0tk9ajak0c8n77790s52"
+        ],
+        "blockNumber": 14400
+      },
+      "nodeAccountList": [
+        {
+          "operator": "zeta1ggqzjf5726uu7xc6pfwg00lny79w6t3a3utpw5",
+          "granteeAddress": "zeta152ka0ynl4p62wwsesd7rmxpcsdh0z437vf3vyr",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepqdljmtptxflv3cs3q79v8pvaynu7ep9eglwvyxv7v3a5mpccvmcg7hpywrc"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta1hk05v9len8u0c2xrwxgfknvcskpd4vncm7ehch",
+          "granteeAddress": "zeta1e07th0309p0mh9s03l79yz08ka8ptu6xsza0cc",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepqf8ngvcs27m4hm8m2e8fupulu3qsvutf7lflds2c0deqmamkdrymvp5u0g6"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta1g323lusfa9qqvjvupajre2dphuem999fahc086",
+          "granteeAddress": "zeta15d004cg8knm8nfklwfpkvfhzcvnl6v0xdkmcmy",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepq2ayeqvgmdau45rqxapal8j5jd6we55y3j7jlphqner8mvtj3jl454mpuhn"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta1mte0r3jzkf2rkd7ex4p3xsd3fxqg7q29q0wxl5",
+          "granteeAddress": "zeta1j8yhw9u7a6kdahg8wpyxy5tzxjjh0f0kwd292z",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepqf7dw2fnf6ntl6f8d3yw7jly8a535cgum9tuur55k2c064pq0ysl5u2fw5m"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta18pksjzclks34qkqyaahf2rakss80mnusju77cm",
+          "granteeAddress": "zeta1euvlmpffq7gl77vlwlv97kn004zq6rdw0skdd3",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepq09ywklml6wts0eua3zhmtcw38rf4kel0zg2d4dhd46zv00mkjz45gn9phl"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta18f7wch6kpfdmk6dk9qqhkszpjwrymev4fpte8p",
+          "granteeAddress": "zeta1l2dwhqy94687yja0upaq0v5aukgdepfw0y253j",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepqdj8ww4u40wkg2whl22qvmm2zdsdn5rt4yegr6zc6sw9zqdvr8mx54nhke5"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta1w8qa37h22h884vxedmprvwtd3z2nwakxu9k935",
+          "granteeAddress": "zeta1mr6rqva6d6gnelu7vwl38h0xn7tl67wac7d43e",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepqwsl5cqjj57aw5rn79j44pyp0322nu6cxx28hfrqn5gwfcaau27tgm3p0z2"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta1j8g8ch4uqgl3gtet3nntvczaeppmlxajqwh5u6",
+          "granteeAddress": "zeta122cx6fts6cn70lpwg3t40lyh9gm83269tdfn79",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepqtft2rac0xtu25v3knnhktyjyp0wehfwj0lg8z24g5asfu0lf0dh7xqyfpf"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta1dxyzsket66vt886ap0gnzlnu5pv0y99v086wnz",
+          "granteeAddress": "zeta1stkv3amjhaheg4zp57w3es3yx0qf59zdl4vld2",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepq02ppdhgdnffaz9mkswx8xu04wlcqjtqc6tgnmsj62fa9ef202v77c9ugp6"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta1w5czgpk5kc9etxw2anzhr0uyrr4fqks32qmk6k",
+          "granteeAddress": "zeta19qjs5kpgrmk0mee06k47s7sss95g6s8g34q7gy",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepq2vduhrgfmvjjjvmh7h90ewm9d98gtj2xkvvduqcgr7lk0ejxgltsngchvu"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta1ymnrwg9e3xr9xkw42ygzjx34dyvwvtc23cnnxz",
+          "granteeAddress": "zeta10ju8dap0u9wf50akjgapwagcu2kejuu2qfmk0z",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepq08m4vw832r4hwt6nwa0fa6ze8c4ue6k9yqjul9ap25hcndv44fsquw5eg2"
+          },
+          "nodeStatus": 4
+        },
+        {
+          "operator": "zeta15ruj2tc76pnj9xtw64utktee7cc7w6vzaes73z",
+          "granteeAddress": "zeta1kd4r2ahxz0vpzulrqrvr7a9t7ukcchrggvefhn",
+          "granteePubkey": {
+            "secp256k1": "zetapub1addwnpepqdy8mm6jemgeyv9g7f7ymk5cymal4zms6t2n0ml0tk9ajak0c8n77790s52"
+          },
+          "nodeStatus": 4
         }
       ],
       "params": {

--- a/scripts/node-setup.sh
+++ b/scripts/node-setup.sh
@@ -117,7 +117,7 @@ zetacored keys add operator --algo=secp256k1 --keyring-backend=$KEYRING
 zetacored keys add hotkey --algo=secp256k1 --keyring-backend=$KEYRING
 operator_address=$(zetacored keys show operator -a --keyring-backend=$KEYRING)
 hotkey_address=$(zetacored keys show hotkey -a --keyring-backend=$KEYRING)
-pubkey=$(zetacored get-pubkey hotkey|sed -e 's/secp256k1:"\(.*\)"/\1/' | sed 's/ //g' )
+pubkey=$(zetacored get-pubkey hotkey --keyring-backend=$KEYRING | sed -e 's/secp256k1:"\(.*\)"/\1/' | sed 's/ //g' )
 echo "operator_address: $operator_address"
 echo "hotkey_address: $hotkey_address"
 echo "pubkey: $pubkey"

--- a/scripts/our-node-setup.sh
+++ b/scripts/our-node-setup.sh
@@ -8,8 +8,8 @@ echo "MONIKER: $MONIKER"
 
 # Reset node
 rm ~/.zetacored/config/genesis.json
-zetacored keys delete operator -y
-zetacored keys delete hotkey -y
+zetacored keys delete operator --keyring-backend=$KEYRING -y 
+zetacored keys delete hotkey --keyring-backend=$KEYRING -y
 rm -rf ~/.zetacored/os_info
 rm -rf ~/.zetacored/config/gentx
 
@@ -22,7 +22,7 @@ zetacored keys add operator --algo=secp256k1 --keyring-backend=$KEYRING
 zetacored keys add hotkey --algo=secp256k1 --keyring-backend=$KEYRING
 operator_address=$(zetacored keys show operator -a --keyring-backend=$KEYRING)
 hotkey_address=$(zetacored keys show hotkey -a --keyring-backend=$KEYRING)
-pubkey=$(zetacored get-pubkey hotkey|sed -e 's/secp256k1:"\(.*\)"/\1/' | sed 's/ //g' )
+pubkey=$(zetacored get-pubkey hotkey --keyring-backend=$KEYRING | sed -e 's/secp256k1:"\(.*\)"/\1/' | sed 's/ //g' )
 echo "operator_address: $operator_address"
 echo "hotkey_address: $hotkey_address"
 echo "pubkey: $pubkey"


### PR DESCRIPTION
1. The `keygen` and `nodeAccountList` configs have been moved from `crosschain` to  `observer`.
2. `zetacored keys delete` cli should add --keyring-backend=$KEYRING flag.
3. `zetacored get-pubkey hotkey` cli should add --keyring-backend=$KEYRING flag. Look at this PR: https://github.com/zeta-chain/node/pull/1424